### PR TITLE
Attempt to wrap [source] blocks with title and anchors

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,7 @@ GIT
 
 GIT
   remote: https://github.com/riboseinc/asciidoctor-rfc
-  revision: 24f0811f3d9962fc8140676ea4f3730ff395c46c
+  revision: 0641b6d9f4324c9bb0830dfbbf1ea1717e7fc85c
   specs:
     asciidoctor-rfc (0.8.0)
       asciidoctor (~> 1.5.6)

--- a/references/informative/asciidoctor-bibliography.xml
+++ b/references/informative/asciidoctor-bibliography.xml
@@ -1,6 +1,6 @@
 <reference  anchor='asciidoctor-bibliography' target='https://github.com/riboseinc/asciidoctor-bibliography/'>
 <front>
-  <title>Citations and Bibliography the "asciidoctor-way"</title>
+  <title>Citations and Bibliography the 'asciidoctor-way'</title>
     <author>
       <organization>Ribose Inc.</organization>
       <address>

--- a/sections/17-biblio.adoc
+++ b/sections/17-biblio.adoc
@@ -1,7 +1,8 @@
 == Bibliography
 
-Asciidoctor natively has a simple encoding of bibliographies, which is not
-adequate for the complexity of bibliographic markup required by RFC XML.
+The simple encoding of bibliography syntax provided by AsciiDoc (and
+Asciidoctor) is inadequate for the complexity of bibliographic markup required
+by RFC XML.
 
 RFC documents overwhelmingly cite other RFC documents, and canonical RFC XML
 bibliographic entries are available at <<IETF-BibXML>>; so it would be
@@ -24,10 +25,17 @@ In the first method, bibliographic citations are handled like all other
 AsciiRFC cross-references. The bibliographic entries for normative and
 informative references are given in the AsciiRFC as passthrough blocks, which
 contain the raw RFC XML for all references; document conversion leaves the raw
-RFC XML in place. This approach requires authors to maintain the normative and
-informative bibliographies within the document, to update them as citations are
-added and removed, and to sort them manually. For example:
+RFC XML in place. 
 
+This approach requires authors to maintain the normative and informative
+bibliographies within the document, to update them as citations are added and
+removed, and to sort them manually. 
+
+For example, the AsciiRFC in <<source-bib-asciirfc-inline>> will generate the
+corresponding RFC XML in <<source-bib-xml-inline>>.
+
+[[source-bib-asciirfc-inline]]
+.Inline Bibliography AsciiRFC 
 [source,asciidoc]
 ----
 Some datagram padding may be needed.<<RFC7253>>
@@ -53,27 +61,30 @@ Some datagram padding may be needed.<<RFC7253>>
 ++++
 ----
 
+[[source-bib-xml-inline]]
+.Inline Bibliography Rendered RFC XML
 [source,xml]
 ----
-<t>Some datagram padding may be needed <xref target="RFC7253"/></t>
+  <t>Some datagram padding may be needed <xref target="RFC7253"/></t>
+</middle>
 
-</middle><back>
+<back>
 <references anchor="_references">
-<name>Normative References</name>
-<reference anchor='RFC7253'
-  target='https://tools.ietf.org/html/rfc7253'>
-  <front>
-    <title>Guidelines for Writing an IANA Considerations
-      Section in RFCs</title> <author initials="T." surname="Krovetz">
-      <organization>Sacramento State</organization>
-    </author>
-    <author initials="P." surname="Rogaway">
-      <organization>UC Davis</organization>
-    </author>
-    <date month='May' year='2014'/>
-  </front>
-  <seriesInfo name="RFC" value="7253"/>
-</reference>
+  <name>Normative References</name>
+  <reference anchor='RFC7253'
+    target='https://tools.ietf.org/html/rfc7253'>
+    <front>
+      <title>Guidelines for Writing an IANA Considerations
+        Section in RFCs</title> <author initials="T." surname="Krovetz">
+        <organization>Sacramento State</organization>
+      </author>
+      <author initials="P." surname="Rogaway">
+        <organization>UC Davis</organization>
+      </author>
+      <date month='May' year='2014'/>
+    </front>
+    <seriesInfo name="RFC" value="7253"/>
+  </reference>
 </references>
 ----
 
@@ -92,7 +103,7 @@ interpreted by the preprocessor; this allows them to be split into normative
 and informative references. (The MMark tool likewise splits reference citations
 into normative and informative.)
 
-Integration with the asciidoc-bibliography gem proceeds as follows:
+Integration with the `asciidoc-bibliography` gem proceeds as follows:
 
 . Create an RFC XML references file, consisting of a `<references>` element
 with individual `<reference>` elements inserted, as would be done for the
@@ -102,11 +113,11 @@ select which references have actually been cited in the document.
 
 .. Rather than hand crafting RFC XML references for RFC documents, you should
 download them from an authoritative source; e.g.
-`http://xml.resource.org/public/rfc/bibxml/reference.RFC.2119.xml`
+`\http://xml.resource.org/public/rfc/bibxml/reference.RFC.2119.xml`
 
 .. Unlike the case for RFC XML documents created manually, the references file
 does not recognise XML entities and will not attempt to download them during
-processing.  Any references to `http://xml.resource.org/public/rfc/bibxml/` will
+processing.  Any references to `\http://xml.resource.org/public/rfc/bibxml/` will
 need to be downloaded and inserted into the references file.
 
 .. The RFC XML in the references file will need to be appropriate to the
@@ -132,7 +143,7 @@ interpolation of the citation.  For example:
 
 ** pass:q[`<<id,words>>`] = `cite:norm[id, text="<xref target='id'>words</xref>"]`
 
-** pass:q[`<<id,format=counter: words>>`] (processed as a formatted crossreference) =
+** pass:q[`<<id,format=counter: words>>`] (processed as a formatted cross-reference) =
   `cite:norm[id, text="<xref format='counter' target='id'>words</xref>"]`
 
 ** pass:q[`<<id,2.4 comma: words>>`] (processed as relref) =
@@ -144,8 +155,10 @@ interpolation of the citation.  For example:
 
 
 . Normative and Informative References are inserted in the document through a
-macro, which occurs where the RFC XML references would be inserted:
+macro, which occurs where the RFC XML references would be inserted <<source-bib-abib>>.
 
+[[source-bib-abib]]
+.Inline Bibliography Rendered RFC XML
 [source,asciidoc]
 --
 [bibliography]


### PR DESCRIPTION
According to https://github.com/riboseinc/asciidoctor-rfc#source-code-listings, AsciiRFC supports giving title and anchors to `[source]` blocks.

This PR attempts that, but I get the following error messages:

```
bundle exec asciidoctor -r ./lib/glob-include-processor.rb -r asciidoctor-rfc -b rfc2 draft-ribose-asciirfc.adoc --trace > draft-ribose-asciirfc.xml
asciidoctor: WARNING (Section: RFC XML features not supported in Asciidoctor): row 0 of table is longer than 72 ascii characters
asciidoctor: WARNING (Section: RFC XML features not supported in Asciidoctor): row 2 of table is longer than 72 ascii characters
element xref: validity error : IDREF attribute target references an unknown ID "source-bib-abib"
element xref: validity error : IDREF attribute target references an unknown ID "source-bib-asciirfc-inline"
element xref: validity error : IDREF attribute target references an unknown ID "source-bib-xml-inline"
xml2rfc --text draft-ribose-asciirfc.xml draft-ribose-asciirfc.txt
Parsing file draft-ribose-asciirfc.xml
ERROR: Unable to validate the XML document: draft-ribose-asciirfc.xml
 <string>: Line 1652: IDREF attribute target references an unknown ID "source-bib-abib"
 <string>: Line 1554: IDREF attribute target references an unknown ID "source-bib-xml-inline"
 <string>: Line 1553: IDREF attribute target references an unknown ID "source-bib-asciirfc-inline"
make: *** [draft-ribose-asciirfc.txt] Error 1
```

If I give a title and anchor (and reference it) using the `....` one (https://github.com/riboseinc/asciidoctor-rfc#ascii-art-and-images), it works.

@opoudjis could you please help? Thanks!